### PR TITLE
Ensure LocalLocation.lastModified() is updated when underlying file is modified

### DIFF
--- a/twill-common/src/main/java/org/apache/twill/filesystem/LocalLocation.java
+++ b/twill-common/src/main/java/org/apache/twill/filesystem/LocalLocation.java
@@ -288,12 +288,14 @@ final class LocalLocation implements Location {
   }
 
   @Override
-  public long lastModified() {
-    return file.lastModified();
+  public long lastModified() throws IOException {
+    // Use Files.getLastModifiedTime() instead of file.lastModified() as file object caches
+    // the last modified time and doesn't update the value when the underlying file has changed.
+    return Files.getLastModifiedTime(file.toPath()).toMillis();
   }
 
   @Override
-  public boolean isDirectory() throws IOException {
+  public boolean isDirectory() {
     return file.isDirectory();
   }
 

--- a/twill-yarn/src/test/java/org/apache/twill/filesystem/LocalLocationTest.java
+++ b/twill-yarn/src/test/java/org/apache/twill/filesystem/LocalLocationTest.java
@@ -18,14 +18,23 @@
 package org.apache.twill.filesystem;
 
 import org.apache.hadoop.security.UserGroupInformation;
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 
 /**
  *
  */
 public class LocalLocationTest extends LocationTestBase {
+
+  @ClassRule
+  public static final TemporaryFolder TEMP_FOLDER = new TemporaryFolder();
 
   @Override
   protected LocationFactory createLocationFactory(String pathBase) throws Exception {
@@ -39,5 +48,28 @@ public class LocalLocationTest extends LocationTestBase {
   protected UserGroupInformation createTestUGI() throws IOException {
     // In local location, UGI is not supported, hence using the current user as the testing ugi.
     return UserGroupInformation.getCurrentUser();
+  }
+
+  @Test
+  public void testLastModified() throws IOException, InterruptedException {
+    LocationFactory lf = new LocalLocationFactory(TEMP_FOLDER.newFolder());
+    Location location = lf.create("test1");
+    String message = "message";
+    try (OutputStream os = location.getOutputStream()) {
+      os.write(message.getBytes(StandardCharsets.UTF_8));
+    }
+    long initialModificationTimestamp = location.lastModified();
+
+    // Modify file, last modified time should get updated.
+    // Sleep for a while, in case the filesystem is very fast.
+    Thread.sleep(1);
+    try (OutputStream os = location.getOutputStream()) {
+      os.write(message.getBytes(StandardCharsets.UTF_8));
+    }
+    long secondModificationTimestamp = location.lastModified();
+    Assert.assertTrue(String.format(
+                        "initialModificationTimestamp(%d) is not less than secondModificationTimestamp(%d)",
+                        initialModificationTimestamp, secondModificationTimestamp),
+                      initialModificationTimestamp < secondModificationTimestamp);
   }
 }


### PR DESCRIPTION
[CDAP-19381](https://cdap.atlassian.net/browse/CDAP-19381)  
File objects use a cached version of lastModified time. As a result calls to the `lastModified()` method return stale values when the underlying file has changed. 

The solution is to use the `Files.getLastModifiedTime` function instead. 

References:
* https://stackoverflow.com/a/42441442/15196379