### PR TITLE
[CDAP-19833] Upgrade actions/cache to v3 which has node16 support

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,7 +43,7 @@ jobs:
           ref: ${{ matrix.branch }}
 
       - name: Cache
-        uses: actions/cache@v2.1.3
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ github.workflow }}-${{ hashFiles('**/pom.xml') }}


### PR DESCRIPTION
Recently we started seeing this warning in github action builds that `Node.js 12 actions are deprecated`.

```
Warning: Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/cache, actions/cache

```
This PR helps in upgrading the `actions/cache` to `v3` which has node16 support.