### PR TITLE
Fix security vulnerabilities due to netty dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
         <guava.version>13.0.1</guava.version>
         <gson.version>2.2.4</gson.version>
         <findbugs.jsr305.version>2.0.1</findbugs.jsr305.version>
-        <netty.version>4.1.16.Final</netty.version>
+        <netty.version>4.1.75.Final</netty.version>
         <snappy-java.version>1.0.5</snappy-java.version>
         <jcl-over-slf4j.version>1.7.2</jcl-over-slf4j.version>
         <asm.version>7.1</asm.version>


### PR DESCRIPTION
## Vulnerability Details:
CVE-2019-20444
CVE-2019-20445
CVE-2015-2156
CVE-2019-16869
CVE-2019-9518
CVE-2020-7238
CVE-2021-37136
CVE-2021-37137
CVE-2021-43797
CVE-2021-21295
CVE-2021-21290
CVE-2014-0193

## Change:
updated `netty.version` from `4.1.16.Final` to `4.1.71.Final`