### PR TITLE
Revert Hadoop Version Bump and Exclude log4j from Hadoop

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -798,6 +798,10 @@
                         <groupId>io.netty</groupId>
                         <artifactId>netty</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>log4j</groupId>
+                        <artifactId>log4j</artifactId>
+                    </exclusion>
                   <exclusion>
                     <groupId>asm</groupId>
                     <artifactId>asm</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -112,8 +112,6 @@
         <commons-compress.version>1.5</commons-compress.version>
         <force.mac.tests>false</force.mac.tests>
         <scala.version>2.12.10</scala.version>
-        <!-- Used by hadoop-hdfs. Keep up-to-date with version in hadoop-hdfs. -->
-        <mockito.version>1.8.5</mockito.version>
     </properties>
 
     <build>
@@ -562,38 +560,6 @@
             <properties>
                 <hadoop.version>2.6.5</hadoop.version>
             </properties>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>build-helper-maven-plugin</artifactId>
-                        <version>1.8</version>
-                        <executions>
-                            <execution>
-                                <id>add-source</id>
-                                <phase>generate-sources</phase>
-                                <goals>
-                                    <goal>add-source</goal>
-                                </goals>
-                                <configuration>
-                                    <sources>
-                                        <source>src/main/hadoop21</source>
-                                        <source>src/main/hadoop22</source>
-                                        <source>src/main/hadoop23</source>
-                                        <source>src/main/hadoop26</source>
-                                    </sources>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
-            <id>hadoop-2.10</id>
-            <properties>
-                <hadoop.version>2.10.2</hadoop.version>
-            </properties>
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
@@ -616,7 +582,6 @@
                                         <source>src/main/hadoop22</source>
                                         <source>src/main/hadoop23</source>
                                         <source>src/main/hadoop26</source>
-                                        <source>src/main/hadoop210</source>
                                     </sources>
                                 </configuration>
                             </execution>
@@ -971,11 +936,6 @@
                 <groupId>org.scala-lang</groupId>
                 <artifactId>scala-library</artifactId>
                 <version>${scala.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.mockito</groupId>
-                <artifactId>mockito-all</artifactId>
-                <version>${mockito.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/twill-yarn/pom.xml
+++ b/twill-yarn/pom.xml
@@ -89,11 +89,6 @@
             <artifactId>asm-commons</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/twill-yarn/src/main/java/org/apache/twill/internal/yarn/AbstractYarnTwillService.java
+++ b/twill-yarn/src/main/java/org/apache/twill/internal/yarn/AbstractYarnTwillService.java
@@ -99,6 +99,9 @@ public abstract class AbstractYarnTwillService extends AbstractTwillService {
       }
 
       UserGroupInformation.getCurrentUser().addCredentials(credentials);
+
+      // Clone the HDFS tokens for HA NameNode. This is to workaround bug HDFS-9276.
+      YarnUtils.cloneHaNnCredentials(config);
       this.credentials = credentials;
 
       LOG.info("Secure store updated from {}.", location);

--- a/twill-yarn/src/main/java/org/apache/twill/internal/yarn/YarnUtils.java
+++ b/twill-yarn/src/main/java/org/apache/twill/internal/yarn/YarnUtils.java
@@ -21,13 +21,17 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.hdfs.DFSUtil;
+import org.apache.hadoop.hdfs.HAUtil;
 import org.apache.hadoop.io.DataInputByteBuffer;
 import org.apache.hadoop.io.DataOutputBuffer;
 import org.apache.hadoop.security.Credentials;
 import org.apache.hadoop.security.SecurityUtil;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.token.Token;
+import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.api.records.LocalResourceType;
 import org.apache.hadoop.yarn.api.records.LocalResourceVisibility;
 import org.apache.hadoop.yarn.api.records.Resource;
@@ -43,9 +47,12 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.net.InetSocketAddress;
+import java.net.URI;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.Nullable;
 
@@ -66,6 +73,32 @@ public class YarnUtils {
     HADOOP_22,
     HADOOP_23,
     HADOOP_26
+  }
+
+  private static boolean hasDFSUtilClient = false; // use this to judge if the hadoop version is above 2.8
+
+  private static boolean hasHAUtilsClient = false;
+
+  private static Method getHaNnRpcAddressesMethod;
+
+  private static Method cloneDelegationTokenForLogicalUriMethod;
+
+  static {
+    try {
+      Class dfsUtilsClientClazz = Class.forName("org.apache.hadoop.hdfs.DFSUtilClient");
+      getHaNnRpcAddressesMethod = dfsUtilsClientClazz.getMethod("getHaNnRpcAddresses",
+          Configuration.class);
+      hasDFSUtilClient = true;
+      Class haUtilClientClazz = Class.forName("org.apache.hadoop.hdfs.HAUtilClient");
+      cloneDelegationTokenForLogicalUriMethod = haUtilClientClazz.getMethod(
+          "cloneDelegationTokenForLogicalUri", UserGroupInformation.class,
+          URI.class, Collection.class);
+      hasHAUtilsClient = true;
+    } catch (ClassNotFoundException e) {
+      LOG.debug("No such class", e);
+    } catch (NoSuchMethodException e) {
+      LOG.debug("No such method", e);
+    }
   }
 
   private static final AtomicReference<HadoopVersions> HADOOP_VERSION = new AtomicReference<>();
@@ -141,6 +174,62 @@ public class YarnUtils {
 
       return tokens == null ? ImmutableList.<Token<?>>of() : ImmutableList.copyOf(tokens);
     }
+  }
+
+  /**
+   * Clones the delegation token to individual host behind the same logical address.
+   *
+   * @param config the hadoop configuration
+   * @throws IOException if failed to get information for the current user.
+   */
+  public static void cloneHaNnCredentials(Configuration config) throws IOException {
+    String scheme = URI.create(config.get(CommonConfigurationKeysPublic.FS_DEFAULT_NAME_KEY,
+                                          CommonConfigurationKeysPublic.FS_DEFAULT_NAME_DEFAULT)).getScheme();
+
+    // Loop through all name services. Each name service could have multiple name node associated with it.
+    for (Map.Entry<String, Map<String, InetSocketAddress>> entry : getHaNnRpcAddresses(config).entrySet()) {
+      String nsId = entry.getKey();
+      Map<String, InetSocketAddress> addressesInNN = entry.getValue();
+      if (!HAUtil.isHAEnabled(config, nsId) || addressesInNN == null || addressesInNN.isEmpty()) {
+        continue;
+      }
+
+      // The client may have a delegation token set for the logical
+      // URI of the cluster. Clone this token to apply to each of the
+      // underlying IPC addresses so that the IPC code can find it.
+      URI uri = URI.create(scheme + "://" + nsId);
+
+      LOG.info("Cloning delegation token for uri {}", uri);
+      cloneDelegationTokenForLogicalUri(UserGroupInformation.getCurrentUser(), uri, addressesInNN.values());
+    }
+  }
+
+  /**
+   * When hadoop_version > 2.8.0, class HAUtil has no method cloneDelegationTokenForLogicalUri(Configuration config)
+   *
+   */
+  private static void cloneDelegationTokenForLogicalUri(UserGroupInformation ugi, URI haUri,
+                                                        Collection<InetSocketAddress> nnAddrs) {
+    if (hasHAUtilsClient) {
+      invokeStaticMethodWithExceptionHandled(cloneDelegationTokenForLogicalUriMethod, ugi, haUri, nnAddrs);
+    } else {
+      HAUtil.cloneDelegationTokenForLogicalUri(ugi, haUri, nnAddrs);
+    }
+  }
+
+
+  /**
+   * When hadoop_version > 2.8.0, class DFSUtils has no method getHaNnRpcAddresses(Configuration config)
+   * @param config
+   * @return
+   */
+  private static Map<String, Map<String, InetSocketAddress>> getHaNnRpcAddresses(Configuration config) {
+    return hasDFSUtilClient ? getHaNnRpcAddressesUseDFSUtilClient(config) :
+        DFSUtil.getHaNnRpcAddresses(config);
+  }
+
+  private static Map<String, Map<String, InetSocketAddress>> getHaNnRpcAddressesUseDFSUtilClient(Configuration config) {
+    return (Map) invokeStaticMethodWithExceptionHandled(getHaNnRpcAddressesMethod, config);
   }
 
   private static Object invokeStaticMethodWithExceptionHandled(Method method, Object ... args) {


### PR DESCRIPTION
This conflicts with hadoop version in CDAP.