### PR TITLE
[CDAP-20734] Fix performance regression being caused by 5 second sleep

### DIFF
--- a/twill-yarn/src/main/java/org/apache/twill/internal/appmaster/ApplicationMasterMain.java
+++ b/twill-yarn/src/main/java/org/apache/twill/internal/appmaster/ApplicationMasterMain.java
@@ -90,9 +90,9 @@ public final class ApplicationMasterMain extends ServiceMain {
     TrackerService trackerService = new TrackerService(service);
 
     List<Service> prerequisites = Lists.newArrayList(
-      new YarnAMClientService(amClient, trackerService),
-      zkClientService,
-      new AppMasterTwillZKPathService(zkClientService, runId)
+        zkClientService,
+        new AppMasterTwillZKPathService(zkClientService, runId),
+        new YarnAMClientService(amClient, trackerService)
     );
 
     if (twillRuntimeSpec.isLogCollectionEnabled()) {

--- a/twill-yarn/src/main/java/org/apache/twill/yarn/YarnTwillController.java
+++ b/twill-yarn/src/main/java/org/apache/twill/yarn/YarnTwillController.java
@@ -294,7 +294,7 @@ final class YarnTwillController extends AbstractTwillController implements Twill
               LOG.debug("Timeout in exists call on ZK path {}.", getInstancePath(), e);
             }
 
-            TimeUnit.SECONDS.sleep(5);
+            TimeUnit.SECONDS.sleep(1);
             report = processController.getReport();
           }
         } catch (InterruptedException e) {


### PR DESCRIPTION
Fix performance regression being caused by 5 second sleep

Also reverses the order of pre-req services such that YarnAMClientService stops first. This reduces the need for the second poll when polling status